### PR TITLE
feat(option): add Option entity with DAO, SQL mapping, and tests

### DIFF
--- a/SurveyApp.API.Tests/DAOs/OptionDaoTests.cs
+++ b/SurveyApp.API.Tests/DAOs/OptionDaoTests.cs
@@ -1,0 +1,34 @@
+using SurveyApp.API.DAOs;
+using SurveyApp.API.DAOs.Interfaces;
+using SurveyApp.API.Models;
+using SurveyApp.API.Tests.Fixtures;
+using Xunit;
+
+namespace SurveyApp.API.Tests.DAOs;
+
+public class OptionDaoTests : IClassFixture<DatabaseFixture>
+{
+  private readonly IOptionDao _optionDao;
+
+  public OptionDaoTests(DatabaseFixture fixture)
+  {
+    _optionDao = fixture.GetService<IOptionDao>(); // no cast
+  }
+  [Fact]
+  public void Insert_And_GetById_ShouldWorkCorrectly()
+  {
+    var option = new Option
+    {
+      SurveyId = 1,
+      Text = "Test Option",
+      CreatedAt = DateTime.UtcNow
+    };
+
+    _optionDao.Insert(option);
+    var result = _optionDao.GetById(option.Id);
+
+    Assert.NotNull(result);
+    Assert.Equal(option.Text, result?.Text);
+    Assert.Equal(option.SurveyId, result?.SurveyId);
+  }
+}

--- a/SurveyApp.API/Controllers/TestController.cs
+++ b/SurveyApp.API/Controllers/TestController.cs
@@ -15,13 +15,15 @@ public class TestController : ControllerBase
   private readonly IUserDao _userDao;
   private readonly IJwtTokenService _jwtTokenService;
   private readonly ISurveyDao _surveyDao;
+  private readonly IOptionDao _optionDao;
 
-  public TestController(IUserDao userDao, IJwtTokenService jwtTokenService, ISurveyDao surveyDao)
+  public TestController(IUserDao userDao, IJwtTokenService jwtTokenService, ISurveyDao surveyDao, IOptionDao optionDao)
   {
+    _optionDao = optionDao;
     _userDao = userDao;
     _jwtTokenService = jwtTokenService;
     _surveyDao = surveyDao;
-    Console.WriteLine("🧪 SurveyDao injected: " + (surveyDao != null));
+    Console.WriteLine("🧪 OptionDao injected: " + (optionDao != null));
   }
 
   [Authorize]
@@ -54,6 +56,21 @@ public class TestController : ControllerBase
 
     _surveyDao.Insert(survey);
     var result = _surveyDao.GetById(survey.Id);
+
+    return Ok(result);
+  }
+  [HttpPost("option")]
+  public IActionResult TestInsertOption()
+  {
+    var option = new Option
+    {
+      Text = "Manual Survey",
+      SurveyId = 1,
+      CreatedAt = DateTime.UtcNow
+    };
+
+    _optionDao.Insert(option);
+    var result = _optionDao.GetById(option.Id);
 
     return Ok(result);
   }

--- a/SurveyApp.API/DAOs/Interfaces/IOptionDao.cs
+++ b/SurveyApp.API/DAOs/Interfaces/IOptionDao.cs
@@ -1,0 +1,10 @@
+using SurveyApp.API.Models;
+
+namespace SurveyApp.API.DAOs.Interfaces;
+
+public interface IOptionDao
+{
+  Option Insert(Option option);
+  Option? GetById(int id);
+  IEnumerable<Option> GetAll();
+}

--- a/SurveyApp.API/DAOs/OptionDao.cs
+++ b/SurveyApp.API/DAOs/OptionDao.cs
@@ -1,0 +1,48 @@
+using SqlBatis.DataMapper;
+using SurveyApp.API.DAOs.Interfaces;
+using SurveyApp.API.Models;
+
+namespace SurveyApp.API.DAOs;
+
+public class OptionDao : IOptionDao
+{
+  private readonly ISqlMapper _mapper;
+
+  public OptionDao(ISqlMapper mapper)
+  {
+    _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
+  }
+  public Option Insert(Option option)
+  {
+    Console.WriteLine("📥 DAO Insert START for " + option.Text);
+    try
+    {
+      _mapper.Insert("Options.Insert", option);
+
+      var inserted = _mapper.QueryForObject<Option>("Options.GetByText", option.Text);
+      if (inserted == null)
+        throw new Exception("Failed to retrieve inserted record");
+
+      option.Id = inserted.Id;
+
+      Console.WriteLine("✅ DAO Insert DONE with ID: " + option.Id);
+      return option;
+    }
+    catch (Exception ex)
+    {
+      Console.WriteLine("🔥 DAO ERROR: " + ex.Message);
+      Console.WriteLine("🔥 STACK: " + ex.StackTrace);
+      throw;
+    }
+  }
+
+  public Option? GetById(int id)
+  {
+    return _mapper.QueryForObject<Option>("Options.GetById", id);
+  }
+
+  public IEnumerable<Option> GetAll()
+  {
+    return _mapper.QueryForList<Option>("Options.GetAll", null);
+  }
+}

--- a/SurveyApp.API/Models/Option.cs
+++ b/SurveyApp.API/Models/Option.cs
@@ -1,0 +1,9 @@
+namespace SurveyApp.API.Models;
+
+public class Option
+{
+  public int Id { get; set; }
+  public string Text { get; set; } = string.Empty;
+  public int SurveyId { get; set; }
+  public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/SurveyApp.API/Program.cs
+++ b/SurveyApp.API/Program.cs
@@ -60,6 +60,8 @@ builder.Services.AddScoped<IUserDao, UserDao>();
 
 Console.WriteLine("🔍 Registering SurveyDao...");
 builder.Services.AddScoped<ISurveyDao, SurveyDao>();
+builder.Services.AddScoped<IOptionDao, OptionDao>();
+
 Console.WriteLine("🔍 Registering DAOs DONE.");
 
 var app = builder.Build();

--- a/SurveyApp.API/SqlMaps/Options.xml
+++ b/SurveyApp.API/SqlMaps/Options.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<sqlMap namespace="Options"
+        xmlns="http://ibatis.apache.org/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <statements>
+
+<insert id="Insert" parameterClass="SurveyApp.API.Models.Option">
+  <![CDATA[
+    INSERT INTO Options (SurveyId, Text, CreatedAt)
+    VALUES (#SurveyId#, #Text#, #CreatedAt#)
+  ]]>
+  <selectKey property="Id" type="post" resultClass="int">
+    SELECT CAST(SCOPE_IDENTITY() AS int)
+  </selectKey>
+</insert>
+
+
+<select id="GetById" resultClass="SurveyApp.API.Models.Option">
+  <![CDATA[
+    SELECT Id, SurveyId, Text, CreatedAt
+    FROM Options
+    WHERE Id = #value#
+  ]]>
+</select>
+
+<select id="GetAll" resultClass="SurveyApp.API.Models.Option">
+  <![CDATA[
+    SELECT Id, SurveyId, Text, CreatedAt
+    FROM Options
+  ]]>
+</select>
+<select id="GetByText" resultClass="SurveyApp.API.Models.Option">
+  <![CDATA[
+    SELECT TOP 1 Id, SurveyId, Text, CreatedAt
+    FROM Options
+    WHERE Text = #value#
+    ORDER BY Id DESC
+  ]]>
+</select>
+
+
+
+  </statements>
+</sqlMap>

--- a/SurveyApp.API/SqlMaps/SqlMap.config
+++ b/SurveyApp.API/SqlMaps/SqlMap.config
@@ -14,5 +14,7 @@
   <sqlMaps>
     <sqlMap embedded="SurveyApp.API.SqlMaps.Users.xml, SurveyApp.API"/>
     <sqlMap embedded="SurveyApp.API.SqlMaps.Surveys.xml, SurveyApp.API"/>
+    <sqlMap embedded="SurveyApp.API.SqlMaps.Options.xml, SurveyApp.API"/>
+
   </sqlMaps>
 </sqlMapConfig>


### PR DESCRIPTION
- Created Option model with Id, Text, SurveyId, CreatedAt fields
- Implemented IOptionDao and OptionDao with insert/get methods
- Added iBatis XML mapping for Option (insert, getById, getAll)
- Registered OptionDao in Program.cs DI container
- Added unit test for OptionDao insert and retrieval
- Extended TestController with manual Option insert