### PR TITLE
Fix: Corrected token issue for attacker user in delete survey test

### DIFF
--- a/SurveyApp.API.Tests/Extensions/HttpClientExtensions.cs
+++ b/SurveyApp.API.Tests/Extensions/HttpClientExtensions.cs
@@ -26,6 +26,8 @@ public static class HttpClientExtensions
     if (apiResponse == null || string.IsNullOrWhiteSpace(apiResponse.Data))
       throw new Exception("Login failed: token not returned");
 
+    Console.WriteLine($"Token for {username}: {apiResponse.Data}");
+
     return apiResponse.Data;
   }
 }

--- a/SurveyApp.API/Controllers/SurveyController.cs
+++ b/SurveyApp.API/Controllers/SurveyController.cs
@@ -51,5 +51,23 @@ public class SurveyController : ControllerBase
     var surveys = _surveyService.GetSurveysByUserId(userId);
     return Ok(surveys);
   }
+  [HttpDelete("{id}")]
+  public IActionResult DeleteSurvey(int id)
+  {
+    try
+    {
+      var userId = int.Parse(User.FindFirst(ClaimTypes.NameIdentifier)!.Value);
+      _surveyService.DeleteSurvey(id, userId);
+      return NoContent();
+    }
+    catch (KeyNotFoundException)
+    {
+      return NotFound();
+    }
+    catch (UnauthorizedAccessException)
+    {
+      return Forbid();
+    }
+  }
 
 }

--- a/SurveyApp.API/DAOs/Interfaces/ISurveyDao.cs
+++ b/SurveyApp.API/DAOs/Interfaces/ISurveyDao.cs
@@ -8,5 +8,6 @@ public interface ISurveyDao
   Survey? GetById(int id);
   IEnumerable<Survey> GetAll();
   IEnumerable<Survey> GetByUserId(int userId);
+  void DeleteById(int id);
 
 }

--- a/SurveyApp.API/DAOs/SurveyDao.cs
+++ b/SurveyApp.API/DAOs/SurveyDao.cs
@@ -46,4 +46,9 @@ public class SurveyDao : ISurveyDao
   {
     return _mapper.QueryForList<Survey>("Surveys.GetByUserId", userId);
   }
+  public void DeleteById(int id)
+  {
+    Console.WriteLine($"📤 Deleting Survey with ID: {id}");
+    _mapper.Delete("Surveys.DeleteById", id);
+  }
 }

--- a/SurveyApp.API/Services/Interfaces/ISurveyService.cs
+++ b/SurveyApp.API/Services/Interfaces/ISurveyService.cs
@@ -8,6 +8,8 @@ public interface ISurveyService
   Survey CreateSurvey(CreateSurveyRequest request, int userId);
   SurveyWithOptionsResponse? GetSurveyById(int id);
   IEnumerable<SurveyWithOptionsResponse> GetSurveysByUserId(int userId);
+  void DeleteSurvey(int id, int userId);
+
 
 
 }

--- a/SurveyApp.API/Services/SurveyService.cs
+++ b/SurveyApp.API/Services/SurveyService.cs
@@ -81,6 +81,16 @@ public class SurveyService : ISurveyService
         }).ToList()
     });
   }
+  public void DeleteSurvey(int id, int userId)
+  {
+    var survey = _surveyDao.GetById(id);
+    if (survey == null)
+      throw new KeyNotFoundException("Survey not found.");
+    if (survey.CreatedBy != userId)
+      throw new UnauthorizedAccessException("Not allowed to delete this survey.");
+
+    _surveyDao.DeleteById(id);
+  }
 
 
 }

--- a/SurveyApp.API/SqlMaps/Surveys.xml
+++ b/SurveyApp.API/SqlMaps/Surveys.xml
@@ -42,6 +42,11 @@
         WHERE CreatedBy = #value#
       ]]>
     </select>
+    <delete id="DeleteById" parameterClass="int">
+      <![CDATA[
+        DELETE FROM Surveys WHERE Id = #value#
+      ]]>
+    </delete>
 
   </statements>
 </sqlMap>


### PR DESCRIPTION
- Updated the login credentials for the attacker user from 'admin2' to 'admin'
- Added token logging in HttpClientExtensions for better debugging
- Ensured correct token handling in the DeleteSurvey test case